### PR TITLE
Skip execution for non-gauge projects

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -27,6 +27,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -108,10 +110,9 @@ public class GaugeExecutionMojo extends AbstractMojo {
 
     /** {@inheritDoc} */
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (!verifyParameters()) {
+        if (!isGaugeProject() || !verifyParameters()) {
             return;
         }
-
         try {
             GaugeCommand.execute(classpath, getCommand());
         } catch (GaugeExecutionFailedException e) {
@@ -120,6 +121,10 @@ public class GaugeExecutionMojo extends AbstractMojo {
             throw new MojoExecutionException("Error executing specs. " + e.getMessage(), e);
         }
 
+    }
+
+    private boolean isGaugeProject() {
+        return Files.exists(Paths.get(dir.getAbsolutePath(), "manifest.json"));
     }
 
     public boolean verifyParameters() {


### PR DESCRIPTION
plugin checks now whether the project to run on is actually a Gauge project (identified by the `manifest.json`) and skips execution if the check fails.

This solves the issue of #35 as it does not try to execute on a parent of a multimodule.

fyi: the second problem in #35 about wrong paths has already been solved in a version later as the issue was created