### PR TITLE
#54 - tableRows as property instead of flag

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
@@ -20,6 +20,7 @@ public class GaugeCommand {
     static final String NODES_FLAG = "-n";
     static final String GAUGE_CUSTOM_CLASSPATH_ENV = "gauge_custom_classpath";
     static final String ENV_FLAG = "--env";
+    static final String TABLEROWS_FLAG = "--table-rows";
     static final String REPEAT_FLAG = "--repeat";
     static final String FAILED_FLAG = "--failed";
 

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -64,6 +64,12 @@ public class GaugeExecutionMojo extends AbstractMojo {
     private String scenario;
 
     /**
+     * Scenario to execute.
+     */
+    @Parameter(property = "tableRows", required = false)
+    private String tableRows;
+
+    /**
      * Set to true to execute specs in parallel
      */
     @Parameter(defaultValue = "${gauge.exec.inParallel}", property = "inParallel", required = false)
@@ -145,6 +151,7 @@ public class GaugeExecutionMojo extends AbstractMojo {
         addAdditionalFlags(command);
         addDir(command);
         addSpecsDir(command);
+        addTableRows(command);
         return command;
     }
 
@@ -160,6 +167,13 @@ public class GaugeExecutionMojo extends AbstractMojo {
 
     private boolean hasRepeatFlag() {
         return this.flags != null && !this.flags.isEmpty() && this.flags.contains(GaugeCommand.REPEAT_FLAG);
+    }
+
+    private void addTableRows(ArrayList<String> command) {
+        if (this.tableRows != null && this.tableRows.trim().length() > 0) {
+            command.add(GaugeCommand.TABLEROWS_FLAG);
+            command.add(tableRows);
+        }
     }
 
     private void addEnv(ArrayList<String> command) {
@@ -223,6 +237,10 @@ public class GaugeExecutionMojo extends AbstractMojo {
 
     public String getSpecsDir() {
         return specsDir;
+    }
+
+    public String getTableRows() {
+        return tableRows;
     }
 
     public String getTags() {

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
@@ -51,6 +51,15 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         assertEquals(true, mojo.isSkipTests());
     }
 
+    public void testSimpleGaugeMojoWithTableRows() throws Exception {
+        File testPom = getPomFile("specs_tableRows.xml");
+
+        GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
+
+        assertNotNull(mojo);
+        assertEquals("1,2", mojo.getTableRows());
+    }
+
     public void testSimpleGaugeMojoToVerifySkipTests() throws Exception {
         File testPom = getPomFile("skip_tests.xml");
 

--- a/src/test/resources/poms/specs_tableRows.xml
+++ b/src/test/resources/poms/specs_tableRows.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.foo</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.thoughtworks.gauge.maven</groupId>
+                <artifactId>gauge-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <specsDir>specs</specsDir>
+                    <tableRows>1,2</tableRows>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>


### PR DESCRIPTION
this introduces the propery `tableRows` to be able to pass a series of table-rows to the maven plugin, that are actually taken into account when executing gauge

see #54 