### PR TITLE
Adds the ability to specify custom environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Run gauge specs in project as a part of maven test phase by adding the below exe
                      <phase>test</phase>
                      <configuration>
                          <specsDir>specs</specsDir>
+                         <environmentVariables>
+                            <CUSTOM_ENV_VARIABLE>value</CUSTOM_ENV_VARIABLE>
+                         </environmentVariables>
                      </configuration>
                      <goals>
                          <goal>execute</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.4.3</version>
+    <version>1.5.0</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
     <url>http://github.com/getgauge/gauge-maven-plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
@@ -7,6 +7,9 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class GaugeCommand {
 
@@ -24,9 +27,9 @@ public class GaugeCommand {
     static final String REPEAT_FLAG = "--repeat";
     static final String FAILED_FLAG = "--failed";
 
-    static void execute(final List<String> classpath, final List<String> command) throws GaugeExecutionFailedException {
+    static void execute(final Map<String, String> environmentVariables, final List<String> classpath, final List<String> command) throws GaugeExecutionFailedException {
         try {
-            ProcessBuilder builder = createProcessBuilder(classpath, command);
+            ProcessBuilder builder = createProcessBuilder(environmentVariables, classpath, command);
             Process process = builder.start();
             Util.InheritIO(process.getInputStream(), System.out);
             Util.InheritIO(process.getErrorStream(), System.err);
@@ -40,11 +43,15 @@ public class GaugeCommand {
         }
     }
 
-    static ProcessBuilder createProcessBuilder(final List<String> classpath, final List<String> command) {
+    static ProcessBuilder createProcessBuilder(final Map<String, String> environmentVariables, final List<String> classpath, final List<String> command) {
         ProcessBuilder builder = new ProcessBuilder();
         builder.command(command);
         final String customClasspath = createCustomClasspath(classpath);
         builder.environment().put(GaugeCommand.GAUGE_CUSTOM_CLASSPATH_ENV, customClasspath);
+        builder.environment().putAll(
+                environmentVariables.entrySet().stream().filter(variable -> Objects.nonNull(variable.getValue()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+        );
         return builder;
     }
 

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -30,7 +30,9 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Goal which executes gauge specs in the project
@@ -114,13 +116,19 @@ public class GaugeExecutionMojo extends AbstractMojo {
     @Parameter(property = "maven.test.skip", defaultValue = "false")
     private boolean skip;
 
+    /**
+     * Additional environment variables to set on the command line.
+     */
+    @Parameter(property = "environmentVariables", readonly = true)
+    private final Map<String, String> environmentVariables = new HashMap<>();
+
     /** {@inheritDoc} */
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!isGaugeProject() || !verifyParameters()) {
             return;
         }
         try {
-            GaugeCommand.execute(classpath, getCommand());
+            GaugeCommand.execute(getEnvironmentVariables(), getClassPath(), getCommand());
         } catch (GaugeExecutionFailedException e) {
             throw new MojoFailureException("Gauge Specs execution failed. " + e.getMessage(), e);
         } catch (Exception e) {
@@ -262,5 +270,13 @@ public class GaugeExecutionMojo extends AbstractMojo {
 
     public boolean isSkip() {
         return skip;
+    }
+
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables;
+    }
+
+    public List<String> getClassPath() {
+        return classpath;
     }
 }

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
@@ -28,7 +28,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.thoughtworks.gauge.maven.GaugeCommand.GAUGE;
 import static com.thoughtworks.gauge.maven.GaugeCommand.VALIDATE;
@@ -66,10 +68,16 @@ public class GaugeValidationMojo extends AbstractMojo {
     @Parameter(defaultValue = "${gauge.exec.additionalFlags}", property = "flags", required = false)
     private List flags;
 
+    /**
+     * Additional environment variables to set on the command line.
+     */
+    @Parameter(property = "environmentVariables", readonly = true)
+    private final Map<String, String> environmentVariables = new HashMap<>();
+
     /** {@inheritDoc} */
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            GaugeCommand.execute(classpath, getCommand());
+            GaugeCommand.execute(getEnvironmentVariables(), getClassPath(), getCommand());
         } catch (GaugeExecutionFailedException e) {
             throw new MojoFailureException("Gauge Specs validation failed. " + e.getMessage(), e);
         } catch (Exception e) {
@@ -102,6 +110,14 @@ public class GaugeValidationMojo extends AbstractMojo {
 
     public String getSpecsDir() {
         return specsDir;
+    }
+
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables;
+    }
+
+    public List<String> getClassPath() {
+        return classpath;
     }
 
 }

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/thoughtworks/gauge/maven/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/GaugeExecutionMojoTestCase.java
@@ -15,16 +15,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Gauge-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
 
-package com.thoughtworks.gauge.maven.tests;
+package com.thoughtworks.gauge.maven;
 
-import com.thoughtworks.gauge.maven.GaugeExecutionMojo;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
@@ -192,6 +193,25 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--repeat");
         assertEquals(expected, actual);
+    }
+
+    public void testCanPassEnvironmentVariable() throws Exception {
+        final File testPom = getPomFile("environment_variables.xml");
+        final GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
+
+        final Map<String, String> expected = new HashMap<>();
+        final String expectedEnvKey = "TEST_KEY";
+        final String expectedEnvValue = "testValue";
+        expected.put(expectedEnvKey, expectedEnvValue);
+
+        final Map<String, String> actual = mojo.getEnvironmentVariables();
+        assertEquals(expected, actual);
+
+        final ProcessBuilder builder = GaugeCommand.createProcessBuilder(actual, mojo.getClassPath(), mojo.getCommand());
+        assertEquals(GaugeCommand.createCustomClasspath(mojo.getClassPath()),
+                builder.environment().get(GaugeCommand.GAUGE_CUSTOM_CLASSPATH_ENV));
+        assertEquals(expectedEnvValue, builder.environment().get(expectedEnvKey));
+
     }
 
     private String getPath(String baseDir, String fileName) {

--- a/src/test/java/com/thoughtworks/gauge/maven/GaugeValidationMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/GaugeValidationMojoTestCase.java
@@ -15,9 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Gauge-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
 
-package com.thoughtworks.gauge.maven.tests;
+package com.thoughtworks.gauge.maven;
 
-import com.thoughtworks.gauge.maven.GaugeValidationMojo;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 
 import java.io.File;

--- a/src/test/resources/poms/environment_variables.xml
+++ b/src/test/resources/poms/environment_variables.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.foo</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.thoughtworks.gauge.maven</groupId>
+                <artifactId>gauge-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <specsDir>specs</specsDir>
+                    <environmentVariables>
+                        <TEST_KEY>testValue</TEST_KEY>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
We have a requirement where we need to pass in different env variables for the same environment.

The workaround is obviously to duplicate the env directory with the different value. However, this would remove the need to do so.