### PR TITLE
Fix Gauge URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 This plugin is used to integrate gauge with maven so that the specs can be run using maven.
 
-Maven plugin to run [Gauge](http://getgauge.io) specs.
+Maven plugin to run [Gauge](https://gauge.org/) specs.
 
 ## Prerequisites
 
-* [Gauge](http://getgauge.io) should be installed and in $PATH (0.9.0 or higher version). Latest version of Gauge can be downloaded using these [instructions](https://docs.gauge.org/getting_started/installing-gauge.html).
+* [Gauge](https://gauge.org/) should be installed and in $PATH (0.9.0 or higher version). Latest version of Gauge can be downloaded using these [instructions](https://docs.gauge.org/getting_started/installing-gauge.html).
 * [Gauge Java plugin](https://github.com/getgauge/gauge-java) 0.6.0 or higher.
 
 ## Create project from archetype


### PR DESCRIPTION
# What
- Fix Gauge URL in README to `https://gauge.org/` since the former URL, `https://getgauge.io/` is used for something other.