### PR TITLE
Use environmentVariables only when absent from system variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Run gauge specs in project as a part of maven test phase by adding the below exe
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.4.0</version>
+             <version>1.6.0</version>
              <executions>
                  <execution>
                      <phase>test</phase>
@@ -147,7 +147,7 @@ Validate gauge specs in project as a part of maven test-compile phase by adding 
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.4.0</version>
+             <version>1.6.0</version>
              <executions>
                  <execution>
                      <phase>test-compile</phase>
@@ -175,7 +175,7 @@ Add the following execution to pom.xml to run both goals:
 <plugin>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
     <executions>
         <execution>
             <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
     <url>http://github.com/getgauge/gauge-maven-plugin</url>
     <description>A maven plugin to execute gauge specs in the project</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.6.0</maven.version>
+        <maven.version>3.8.1</maven.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.5.2</version>
+            <version>3.9.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3</version>
+            <version>3.13.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
@@ -8,8 +8,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class GaugeCommand {
 
@@ -48,10 +46,7 @@ public class GaugeCommand {
         builder.command(command);
         final String customClasspath = createCustomClasspath(classpath);
         builder.environment().put(GaugeCommand.GAUGE_CUSTOM_CLASSPATH_ENV, customClasspath);
-        builder.environment().putAll(
-                environmentVariables.entrySet().stream().filter(variable -> Objects.nonNull(variable.getValue()))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-        );
+        environmentVariables.forEach(builder.environment()::putIfAbsent);
         return builder;
     }
 

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -119,8 +118,8 @@ public class GaugeExecutionMojo extends AbstractMojo {
     /**
      * Additional environment variables to set on the command line.
      */
-    @Parameter(property = "environmentVariables", readonly = true)
-    private final Map<String, String> environmentVariables = new HashMap<>();
+    @Parameter
+    private Map<String, String> environmentVariables;
 
     /** {@inheritDoc} */
     public void execute() throws MojoExecutionException, MojoFailureException {


### PR DESCRIPTION
Changes:

- Updates maven-core and maven-compat dependencies to resolve vulnerabilities
- Removes readonly from environmentVariables parameter
- Updates to use environments variable only when not set in system