### PR TITLE
Fix NPE when environmentVariables is not defined in plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Run gauge specs in project as a part of maven test phase by adding the below exe
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.6.0</version>
+             <version>1.6.1</version>
              <executions>
                  <execution>
                      <phase>test</phase>
@@ -147,7 +147,7 @@ Validate gauge specs in project as a part of maven test-compile phase by adding 
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.6.0</version>
+             <version>1.6.1</version>
              <executions>
                  <execution>
                      <phase>test-compile</phase>
@@ -175,7 +175,7 @@ Add the following execution to pom.xml to run both goals:
 <plugin>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <executions>
         <execution>
             <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
     <url>http://github.com/getgauge/gauge-maven-plugin</url>

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class GaugeCommand {
 
@@ -34,9 +35,7 @@ public class GaugeCommand {
             if (process.waitFor() != 0) {
                 throw new GaugeExecutionFailedException();
             }
-        } catch (InterruptedException e) {
-            throw new GaugeExecutionFailedException(e);
-        } catch (IOException e) {
+        } catch (InterruptedException | IOException e) {
             throw new GaugeExecutionFailedException(e);
         }
     }
@@ -46,7 +45,9 @@ public class GaugeCommand {
         builder.command(command);
         final String customClasspath = createCustomClasspath(classpath);
         builder.environment().put(GaugeCommand.GAUGE_CUSTOM_CLASSPATH_ENV, customClasspath);
-        environmentVariables.forEach(builder.environment()::putIfAbsent);
+        if (Objects.nonNull(environmentVariables)) {
+            environmentVariables.forEach(builder.environment()::putIfAbsent);
+        }
         return builder;
     }
 
@@ -60,7 +61,8 @@ public class GaugeCommand {
     /**
      * Merges the specs path with base dir
      *
-     * @param specsDir
+     * @param dir Parent directory
+     * @param specsDir Specs directory
      * @return Returns absolute path joining base dir with specsDir
      */
     static String getSpecsPath(final File dir, final String specsDir) {

--- a/src/test/java/com/thoughtworks/gauge/maven/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/GaugeExecutionMojoTestCase.java
@@ -214,6 +214,19 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
     }
 
+    public void testCanHandelEmptyEnvironmentVariables() throws Exception {
+        final File testPom = getPomFile("simple_config.xml");
+        final GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
+
+        final Map<String, String> actual = mojo.getEnvironmentVariables();
+        assertNull(actual);
+
+        final ProcessBuilder builder = GaugeCommand.createProcessBuilder(actual, mojo.getClassPath(), mojo.getCommand());
+        assertNotNull(builder.environment());
+        assertEquals(GaugeCommand.createCustomClasspath(mojo.getClassPath()),
+                builder.environment().get(GaugeCommand.GAUGE_CUSTOM_CLASSPATH_ENV));
+    }
+
     private String getPath(String baseDir, String fileName) {
         return new File(baseDir, fileName).getAbsolutePath();
     }


### PR DESCRIPTION
In case when environmentVariables node is not provided in plugin configuration the following exception is thrown on startup

[ERROR] Failed to execute goal com.thoughtworks.gauge.maven:gauge-maven-plugin:1.6.0:execute (default-cli) on project hof-ui-tests: Error executing specs. Cannot invoke "java.util.Map.forEach(java.util.function.BiConsumer)" because "environmentVariables" is null -> [Help 1]

Which is caused by this change https://github.com/getgauge-contrib/gauge-maven-plugin/commit/523fe288360c384054b2bd0c5bd937a01c6750fc

@haroon-sheikh could you please merge. 