### PR TITLE
Bumps dependencies and corrects scopes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: '12.x.x'
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Build with Maven
         run: mvn test package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,11 @@ jobs:
       password: '${{ secrets.maven_deploy_password }}'
       passphrase: '${{ secrets.gpg_passphrase }}'
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: '12.x.x'
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: setup
         run: |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the below snippet to pom.xml
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.4.0</version>
+             <version>1.6.2</version>
          </plugin>
      </plugins>
  </build>
@@ -101,7 +101,7 @@ Run gauge specs in project as a part of maven test phase by adding the below exe
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.6.1</version>
+             <version>1.6.2</version>
              <executions>
                  <execution>
                      <phase>test</phase>
@@ -147,7 +147,7 @@ Validate gauge specs in project as a part of maven test-compile phase by adding 
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.6.1</version>
+             <version>1.6.2</version>
              <executions>
                  <execution>
                      <phase>test-compile</phase>
@@ -175,7 +175,7 @@ Add the following execution to pom.xml to run both goals:
 <plugin>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
     <executions>
         <execution>
             <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2,33 +2,35 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
-    <url>http://github.com/getgauge/gauge-maven-plugin</url>
+    <url>https://github.com/getgauge-contrib/gauge-maven-plugin</url>
     <description>A maven plugin to execute gauge specs in the project</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.8.1</maven.version>
+        <maven.version>3.9.6</maven.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
-            <version>${maven.version}</version>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.11.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -43,21 +45,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.9.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.13.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -65,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -78,7 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -91,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -111,7 +102,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -125,7 +116,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>
@@ -155,7 +146,7 @@
     <licenses>
         <license>
             <name>GNU Public License version 3.0</name>
-            <url>http://www.gnu.org/licenses/gpl-3.0.txt</url>
+            <url>https://www.gnu.org/licenses/gpl-3.0.txt</url>
         </license>
     </licenses>
     <developers>
@@ -163,12 +154,12 @@
             <name>Gauge Team</name>
             <email>getgauge@outlook.com</email>
             <organization>ThoughtWorks</organization>
-            <organizationUrl>http://thoughtworks.com/</organizationUrl>
+            <organizationUrl>https://thoughtworks.com/</organizationUrl>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git@github.com:getgauge/gauge-java.git</connection>
-        <developerConnection>scm:git:git@github.com:getgauge/gauge-java.git</developerConnection>
-        <url>git@github.com:getgauge/gauge-java.git</url>
+        <connection>scm:git:git@github.com:getgauge-contrib/gauge-maven-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:getgauge-contrib/gauge-maven-plugin.git</developerConnection>
+        <url>https://github.com/getgauge-contrib/gauge-maven-plugin</url>
     </scm>
 </project>


### PR DESCRIPTION
Should not have runtime/compile time dependencies on Maven itself, this is provided by the container.

- Fixes https://github.com/getgauge/gauge/issues/2487
- Fixes https://github.com/getgauge-contrib/gauge-maven-plugin/issues/86

For example, this is how the [dependency-check-maven plugin](https://mvnrepository.com/artifact/org.owasp/dependency-check-maven/9.0.9) is set up, as well as something core like the [maven-gpg-plugin](https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-gpg-plugin/3.1.0). (note the `provided` dependencies on maven-core, maven-plugin-api rather than `compile` or `runtime` dependencies)

This is more the canonical approach to the fix suggested in https://github.com/getgauge-contrib/gauge-maven-plugin/pull/85