### PR TITLE
Migrate publishing to Sonatype Central Publisher Portal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $gpgkey
           rm -rf $HOME/.m2
           mkdir -p $HOME/.m2
-          echo -e "<settings>\n<servers>\n<server>\n<id>ossrh</id>\n<username>$username</username>\n<password>$password</password>\n</server>\n</servers>\n</settings>" > $HOME/.m2/settings.xml
+          echo -e "<settings>\n<servers>\n<server>\n<id>central</id>\n<username>$username</username>\n<password>$password</password>\n</server>\n</servers>\n</settings>" > $HOME/.m2/settings.xml
       - name: Deploy
         run: |
           mvn -q clean deploy -Dgpg.passphrase=$passphrase

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the below snippet to pom.xml
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.6.3</version>
+             <version>1.6.4</version>
          </plugin>
      </plugins>
  </build>
@@ -101,7 +101,7 @@ Run gauge specs in project as a part of maven test phase by adding the below exe
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.6.3</version>
+             <version>1.6.4</version>
              <executions>
                  <execution>
                      <phase>test</phase>
@@ -147,7 +147,7 @@ Validate gauge specs in project as a part of maven test-compile phase by adding 
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.6.3</version>
+             <version>1.6.4</version>
              <executions>
                  <execution>
                      <phase>test-compile</phase>
@@ -175,7 +175,7 @@ Add the following execution to pom.xml to run both goals:
 <plugin>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.6.3</version>
+    <version>1.6.4</version>
     <executions>
         <execution>
             <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.6.3</version>
+    <version>1.6.4</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
     <url>https://github.com/getgauge-contrib/gauge-maven-plugin</url>
@@ -100,14 +100,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
         </plugins>
@@ -133,16 +132,6 @@
             </plugins>
         </pluginManagement>
     </build>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
     <licenses>
         <license>
             <name>GNU Public License version 3.0</name>


### PR DESCRIPTION
Publishing will stop working on OSSRH mid June.

https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#process-to-migrate

FYI @sriv - unfortunately I'm not an admin of this repo so cannot update the `username`/`password` Actions secrets with the new publishing username/password. The values are in the 1password vault if you'd like to do it.

I've already migrated the namespace, and switched `gauge-java` and it's working fine there.